### PR TITLE
TNT-41588 Allow property-specific artifact download

### DIFF
--- a/Source/Adobe.Target.Client/OnDevice/RuleLoader.cs
+++ b/Source/Adobe.Target.Client/OnDevice/RuleLoader.cs
@@ -173,7 +173,9 @@ namespace Adobe.Target.Client.OnDevice
         private string GetArtifactUrl()
         {
             return this.clientConfig.Client + "/" + this.clientConfig.OnDeviceEnvironment.ToLowerInvariant()
-                + "/v" + MajorVersion + ArtifactFilename;
+                + "/v" + MajorVersion
+                + (string.IsNullOrEmpty(this.clientConfig.DefaultPropertyToken) ? string.Empty : "/" + this.clientConfig.DefaultPropertyToken)
+                + ArtifactFilename;
         }
 
         private void ProcessResult(PolicyResult<IRestResponse> policyResult)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
When a default property token is specified in SDK config, we should download the property-specific artifact, instead of the full artifact containing all ODD-enabled activities.

## Related Issue

https://jira.corp.adobe.com/browse/TNT-41588
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
