### PR TITLE
Fix TNT-42553 ODD artifact still downloaded via HTTPS when Secure=false

### DIFF
--- a/Source/Adobe.Target.Client/OnDevice/GeoClient.cs
+++ b/Source/Adobe.Target.Client/OnDevice/GeoClient.cs
@@ -10,7 +10,6 @@
  */
 namespace Adobe.Target.Client.OnDevice
 {
-    using System;
     using System.Threading.Tasks;
     using Adobe.Target.Delivery.Model;
     using RestSharp;
@@ -90,7 +89,7 @@ namespace Adobe.Target.Client.OnDevice
 
         private string GetGeoUrl(TargetClientConfig clientConfig)
         {
-            return Uri.UriSchemeHttps + "://" + clientConfig.OnDeviceConfigHostname + GeoPath;
+            return clientConfig.Protocol + clientConfig.OnDeviceConfigHostname + GeoPath;
         }
     }
 }

--- a/Source/Adobe.Target.Client/OnDevice/RuleLoader.cs
+++ b/Source/Adobe.Target.Client/OnDevice/RuleLoader.cs
@@ -134,7 +134,7 @@ namespace Adobe.Target.Client.OnDevice
                 return;
             }
 
-            RestClient client = new (Uri.UriSchemeHttps + "://" + this.clientConfig.OnDeviceConfigHostname);
+            RestClient client = new (this.clientConfig.Protocol + this.clientConfig.OnDeviceConfigHostname);
 
             client.ClearHandlers();
             client.AddDefaultHeader(AcceptHeader, AcceptHeaderValue);

--- a/Source/Adobe.Target.Client/TargetClientConfig.cs
+++ b/Source/Adobe.Target.Client/TargetClientConfig.cs
@@ -26,8 +26,6 @@ namespace Adobe.Target.Client
     {
         private const string ClusterPrefix = "mboxedge";
         private const string DefaultDomain = "tt.omtrdc.net";
-        private const string Https = "https://";
-        private const string Http = "http://";
 
         private TargetClientConfig()
         {
@@ -38,7 +36,7 @@ namespace Adobe.Target.Client
             ValidateConfig(builder);
             this.Client = builder.Client;
             this.OrganizationId = builder.OrganizationId;
-            this.Protocol = builder.Secure ? Https : Http;
+            this.Protocol = $"{(builder.Secure ? Uri.UriSchemeHttps : Uri.UriSchemeHttp)}{Uri.SchemeDelimiter}";
             this.DefaultPropertyToken = builder.DefaultPropertyToken;
             this.DefaultUrl = builder.ServerDomain != DefaultDomain
                 ? $"{this.Protocol}{builder.ServerDomain}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
When Secure SDK config option is set to Secure=false, the expectation is that both calls to Target edge and artifact retrieval from Akamai will go over HTTP, however the actually observed behavior is that only calls to Target edge go over HTTP, but ODD artifact retrieval from Akamai still uses HTTPS.

This should be fixed, so ODD artifact retrieval also takes place over HTTP when Secure=false.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/TNT-42553

