### PR TITLE
TNT-42779 Allow disabling of local artifact update

### DIFF
--- a/Source/Adobe.Target.Client/OnDevice/RuleLoader.cs
+++ b/Source/Adobe.Target.Client/OnDevice/RuleLoader.cs
@@ -60,7 +60,7 @@ namespace Adobe.Target.Client.OnDevice
             this.PollingInterval = clientConfig.OnDeviceDecisioningPollingIntSecs * 1000;
             this.logger = TargetClient.Logger;
             this.SetLocalRules();
-            if (clientConfig.LocalArtifactOnly)
+            if (!clientConfig.UpdateLocalArtifact)
             {
                 return;
             }

--- a/Source/Adobe.Target.Client/TargetClientConfig.cs
+++ b/Source/Adobe.Target.Client/TargetClientConfig.cs
@@ -59,7 +59,7 @@ namespace Adobe.Target.Client
             this.OnDeviceConfigHostname = builder.OnDeviceConfigHostname;
             this.OnDeviceDecisioningPollingIntSecs = builder.OnDeviceDecisioningPollingIntSecs;
             this.OnDeviceArtifactPayload = builder.OnDeviceArtifactPayload;
-            this.LocalArtifactOnly = builder.LocalArtifactOnly;
+            this.UpdateLocalArtifact = builder.UpdateLocalArtifact;
         }
 
         /// <summary>
@@ -98,7 +98,8 @@ namespace Adobe.Target.Client
         public ILogger Logger { get; }
 
         /// <summary>
-        /// Timeout (defaults to 100000 ms)
+        /// Timeout <br/>
+        /// Default: <c>100000ms</c>
         /// </summary>
         public int Timeout { get; }
 
@@ -163,10 +164,10 @@ namespace Adobe.Target.Client
         public string OnDeviceArtifactPayload { get; }
 
         /// <summary>
-        /// When true, Target SDK won't attempt to update the locally set artifact <br/>
-        /// Used together with <see cref="OnDeviceArtifactPayload"/>
+        /// When <c>false</c>, the SDK won't attempt to update the artifact set locally using <see cref="OnDeviceArtifactPayload"/><br/>
+        /// Default: <c>true</c>
         /// </summary>
-        public bool LocalArtifactOnly { get; }
+        public bool UpdateLocalArtifact { get; }
 
         /// <summary>
         /// ClusterUrlPrefix
@@ -302,7 +303,10 @@ namespace Adobe.Target.Client
             /// </summary>
             internal string OnDeviceArtifactPayload { get; private set; }
 
-            internal bool LocalArtifactOnly { get; private set; }
+            /// <summary>
+            /// Update Local Artifact
+            /// </summary>
+            internal bool UpdateLocalArtifact { get; private set; } = true;
 
             /// <summary>
             /// Sets ServerDomain <br/>
@@ -490,8 +494,21 @@ namespace Adobe.Target.Client
             }
 
             /// <summary>
+            /// Sets Update Local Artifact <br/>
+            /// When <c>false</c>, the SDK won't attempt to update the artifact set locally using <see cref="OnDeviceArtifactPayload"/><br/>
+            /// Default: <c>true</c>
+            /// </summary>
+            /// <param name="updateLocalArtifact">Update Local Artifact</param>
+            /// <returns><see cref="Builder"/> instance</returns>
+            public Builder SetUpdateLocalArtifact(bool updateLocalArtifact)
+            {
+                this.UpdateLocalArtifact = updateLocalArtifact;
+                return this;
+            }
+
+            /// <summary>
             /// Sets the number of seconds between OnDevice rule update requests <br/>
-            /// Default: 300
+            /// Default: <c>300s</c>
             /// </summary>
             /// <param name="pollingSeconds">OnDevice Decisioning Polling Interval Seconds</param>
             /// <returns><see cref="Builder"/> instance</returns>
@@ -508,12 +525,6 @@ namespace Adobe.Target.Client
             public TargetClientConfig Build()
             {
                 return new (this);
-            }
-
-            internal Builder SetLocalArtifactOnly(bool localOnly)
-            {
-                this.LocalArtifactOnly = localOnly;
-                return this;
             }
         }
     }

--- a/Tests/Adobe.Target.Client.Test/DecisioningIntegrationTests.cs
+++ b/Tests/Adobe.Target.Client.Test/DecisioningIntegrationTests.cs
@@ -118,7 +118,7 @@ namespace Adobe.Target.Client.Test
         {
             var configBuilder =
                 new TargetClientConfig.Builder((string) config["client"], (string) config["organizationId"])
-                    .SetLocalArtifactOnly(true)
+                    .SetUpdateLocalArtifact(false)
                     .SetOnDeviceArtifactPayload(this.fixture.Artifacts[artifact]);
 
             if (config.ContainsKey("decisioningMethod"))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
When setting a local artifact with `SetOnDeviceArtifactPayload(artifact)`, customers may also want to disable automatic artifact updates, in order to be able to debug a specific artifact version. We also need this functionality in our tests.
This will be implemented via a new configuration option - `SetUpdateLocalArtifact(bool)`, set to true by default.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/TNT-42779