### PR TITLE
TNT-45759 params with dots do not work

### DIFF
--- a/Source/Adobe.Target.Client/Adobe.Target.Client.csproj
+++ b/Source/Adobe.Target.Client/Adobe.Target.Client.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup Label="Project References">
     <PackageReference Include="Adobe.ExperienceCloud.Ecid" Version="1.0.0" />
-    <ProjectReference Include="../Adobe.Target.Delivery/Adobe.Target.Delivery.csproj" />
+    <PackageReference Include="Adobe.Target.Delivery" Version="1.1.3" />
     <PackageReference Include="JsonLogic.Net" Version="1.1.11" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/Source/Adobe.Target.Client/Adobe.Target.Client.csproj
+++ b/Source/Adobe.Target.Client/Adobe.Target.Client.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup Label="Project References">
     <PackageReference Include="Adobe.ExperienceCloud.Ecid" Version="1.0.0" />
-    <PackageReference Include="Adobe.Target.Delivery" Version="1.1.3" />
+    <ProjectReference Include="../Adobe.Target.Delivery/Adobe.Target.Delivery.csproj" />
     <PackageReference Include="JsonLogic.Net" Version="1.1.11" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/Source/Adobe.Target.Client/OnDevice/Collator/CustomParamsCollator.cs
+++ b/Source/Adobe.Target.Client/OnDevice/Collator/CustomParamsCollator.cs
@@ -28,15 +28,14 @@ namespace Adobe.Target.Client.OnDevice.Collator
 
             foreach (var param in requestDetails.Parameters)
             {
-                var paramStringValue = (string)param.Value;
-                result.Add(param.Key, paramStringValue);
-                result.Add(param.Key + LowerCasePostfix, paramStringValue?.ToLowerInvariant());
+                result.Add(param.Key, param.Value);
+                result.Add(param.Key + LowerCasePostfix, param.Value?.ToLowerInvariant());
             }
 
             return this.CreateNestedParametersFromDots(result);
         }
 
-        public Dictionary<string, object> CreateNestedParametersFromDots(Dictionary<string, object> custom)
+        private Dictionary<string, object> CreateNestedParametersFromDots(Dictionary<string, object> custom)
         {
             var result = new Dictionary<string, object>();
             foreach (KeyValuePair<string, object> entry in custom)
@@ -55,7 +54,7 @@ namespace Adobe.Target.Client.OnDevice.Collator
             return result;
         }
 
-        public void AddNestedKeyToParameters(Dictionary<string, object> custom, string key, object value)
+        private void AddNestedKeyToParameters(Dictionary<string, object> custom, string key, object value)
         {
             string[] keys = key.Split('.');
             for (int i = 0; i < keys.Length - 1; i++)

--- a/Source/Adobe.Target.Client/OnDevice/Collator/CustomParamsCollator.cs
+++ b/Source/Adobe.Target.Client/OnDevice/Collator/CustomParamsCollator.cs
@@ -28,11 +28,47 @@ namespace Adobe.Target.Client.OnDevice.Collator
 
             foreach (var param in requestDetails.Parameters)
             {
-                result.Add(param.Key, param.Value);
-                result.Add(param.Key + LowerCasePostfix, param.Value?.ToLowerInvariant());
+                var paramStringValue = (string)param.Value;
+                result.Add(param.Key, paramStringValue);
+                result.Add(param.Key + LowerCasePostfix, paramStringValue?.ToLowerInvariant());
+            }
+
+            return this.CreateNestedParametersFromDots(result);
+        }
+
+        public Dictionary<string, object> CreateNestedParametersFromDots(Dictionary<string, object> custom)
+        {
+            var result = new Dictionary<string, object>();
+            foreach (KeyValuePair<string, object> entry in custom)
+            {
+                if (entry.Key.Contains(".")
+                    && !entry.Key.Contains("..")
+                    && entry.Key[0] != '.'
+                    && entry.Key[entry.Key.Length - 1] != '.')
+                {
+                    this.AddNestedKeyToParameters(result, entry.Key, entry.Value);
+                }
+
+                result.Add(entry.Key, entry.Value);
             }
 
             return result;
+        }
+
+        public void AddNestedKeyToParameters(Dictionary<string, object> custom, string key, object value)
+        {
+            string[] keys = key.Split('.');
+            for (int i = 0; i < keys.Length - 1; i++)
+            {
+                if (!custom.ContainsKey(keys[i]))
+                {
+                    custom.Add(keys[i], new Dictionary<string, object>());
+                }
+
+                custom = (Dictionary<string, object>)custom[keys[i]];
+            }
+
+            custom.Add(keys[keys.Length - 1], value);
         }
     }
 }

--- a/Tests/Adobe.Target.Client.Test/Artifacts/TEST_ARTIFACT_PARAMS.json
+++ b/Tests/Adobe.Target.Client.Test/Artifacts/TEST_ARTIFACT_PARAMS.json
@@ -1,6 +1,7 @@
 {
   "targetAdminActivityUrls": [
-    "https://experience.adobe.com/#/@targettesting/target/activities/activitydetails/A-B/_unit-test_mbox-params"
+    "https://experience.adobe.com/#/@targettesting/target/activities/activitydetails/A-B/_unit-test_mbox-params",
+    "https://experience.adobe.com/#/@targettesting/target/activities/activitydetails/A-B/_unit-test_mbox-params-dots"
   ],
   "version": "1.0.0",
   "meta": { "clientCode": "targettesting", "environment": "production" },
@@ -126,6 +127,63 @@
                 "type": "json",
                 "eventToken": "gsDuhGuCbuMhKLusIlPUI5NWHtnQtQrJfmRrQugEa2qCnQ9Y9OaLL2gsdrWQTvE54PwSz67rmXWmSnkXpSSS2Q==",
                 "content": { "foo": "bar", "isFooBar": true, "experience": "B" }
+              }
+            ],
+            "metrics": []
+          }
+        },
+        {
+          "ruleKey": "147386",
+          "activityId": 147386,
+          "meta": {
+            "activity.id": 147386,
+            "activity.name": "[unit-test] mbox-params-dots",
+            "activity.type": "ab",
+            "experience.id": 0,
+            "experience.name": "Experience A",
+            "location.name": "mbox-params",
+            "location.type": "mbox",
+            "location.id": 0,
+            "audience.ids": [2059251],
+            "offer.id": 320012,
+            "offer.name": "Offer3",
+            "option.id": 2,
+            "option.name": "Offer2"
+          },
+          "condition": {
+            "and": [
+              {
+                "and": [
+                  { "<=": [0, { "var": "allocation" }] },
+                  { ">=": [100, { "var": "allocation" }] }
+                ]
+              },
+              {
+                "and": [
+                  {
+                    "==": [
+                      "racket",
+                      { "var": "mbox.first.programming.language_lc" }
+                    ]
+                  },
+                  { "==": ["red", { "var": "mbox.favorite.color_lc" }] },
+                  {
+                    "==": [
+                      "the big lebowski",
+                      { "var": "mbox.favorite.movie_lc" }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          "consequence": {
+            "name": "mbox-params",
+            "options": [
+              {
+                "type": "json",
+                "eventToken": "WCoBzcT7Wkah1KKwsBiOkWqipfsIHvVzTQxHolz2IpSCnQ9Y9OaLL2gsdrWQTvE54PwSz67rmXWmSnkXpSSS2Q==",
+                "content": { "foo": "bar", "fizz": "buzz", "experience": "C" }
               }
             ],
             "metrics": []

--- a/Tests/Adobe.Target.Client.Test/Models/TEST_SUITE_PARAMS.json
+++ b/Tests/Adobe.Target.Client.Test/Models/TEST_SUITE_PARAMS.json
@@ -17,9 +17,17 @@
           },
           "context": {
             "channel": "web",
+            "mobilePlatform": null,
+            "application": null,
+            "screen": null,
+            "window": null,
+            "browser": null,
             "address": {
-              "url": "http://local-target-test:8080/home?fabulous=true#sosumi"
+              "url": "http://local-target-test:8080/home?fabulous=true#sosumi",
+              "referringUrl": null
             },
+            "geo": null,
+            "timeOffsetInMinutes": null,
             "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:73.0) Gecko/20100101 Firefox/73.0",
             "beacon": false
           },
@@ -69,9 +77,17 @@
           },
           "context": {
             "channel": "web",
+            "mobilePlatform": null,
+            "application": null,
+            "screen": null,
+            "window": null,
+            "browser": null,
             "address": {
-              "url": "http://local-target-test:8080/home?fabulous=true#sosumi"
+              "url": "http://local-target-test:8080/home?fabulous=true#sosumi",
+              "referringUrl": null
             },
+            "geo": null,
+            "timeOffsetInMinutes": null,
             "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:73.0) Gecko/20100101 Firefox/73.0",
             "beacon": false
           },
@@ -95,6 +111,68 @@
             {
               "index": 1,
               "name": "mbox-params"
+            }
+          ]
+        }
+      }
+    },
+    "mbox_params_with_dots": {
+      "description": "supports matching params with dot notation",
+      "input": {
+        "request": {
+          "id": {
+            "tntId": "338e3c1e51f7416a8e1ccba4f81acea0.28_0",
+            "marketingCloudVisitorId": "07327024324407615852294135870030620007"
+          },
+          "context": {
+            "channel": "web",
+            "mobilePlatform": null,
+            "application": null,
+            "screen": null,
+            "window": null,
+            "browser": null,
+            "address": {
+              "url": "http://local-target-test:8080/home?fabulous=true#sosumi",
+              "referringUrl": null
+            },
+            "geo": null,
+            "timeOffsetInMinutes": null,
+            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:73.0) Gecko/20100101 Firefox/73.0",
+            "beacon": false
+          },
+          "prefetch": {
+            "mboxes": [
+              {
+                "name": "mbox-params",
+                "parameters": {
+                  "first.programming.language": "racket",
+                  "favorite.color": "red",
+                  "favorite.movie": "the big lebowski"
+                },
+                "index": 1
+              }
+            ]
+          }
+        },
+        "sessionId": "dummy_session"
+      },
+      "output": {
+        "prefetch": {
+          "mboxes": [
+            {
+              "index": 1,
+              "name": "mbox-params",
+              "options": [
+                {
+                  "type": "json",
+                  "content": {
+                    "foo": "bar",
+                    "fizz": "buzz",
+                    "experience": "C"
+                  },
+                  "eventToken": "WCoBzcT7Wkah1KKwsBiOkWqipfsIHvVzTQxHolz2IpSCnQ9Y9OaLL2gsdrWQTvE54PwSz67rmXWmSnkXpSSS2Q=="
+                }
+              ]
             }
           ]
         }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMajor",
-    "version": "5.0.100"
+    "version": "5.0.202"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Customer created rules that contain dot notation (ex: favorite.color) are now transformed into nested JSON objects so that they can be correctly processed by JsonLogic.

## Related Issue

https://jira.corp.adobe.com/browse/TNT-45759

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
